### PR TITLE
Use "native" target for jvm-toxcore-c.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 java_binary(
     name = "echobot-jvm",
     srcs = glob(["src/main/java/**/*.java"]),
-    data = ["//jvm-toxcore-c:libtox4j-c.so"],
+    data = ["//jvm-toxcore-c:native"],
     jvm_flags = ["-Djava.library.path=jvm-toxcore-c"],
     main_class = "im.tox.echobot.EchoBot",
     resources = glob(["src/main/resources/**/*"]),


### PR DESCRIPTION
This selects the .so or .dylib depending on target platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/echobot-jvm/5)
<!-- Reviewable:end -->
