### PR TITLE
Add bazel rule for echobot test.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("//tools/project:build_defs.bzl", "project")
+load("//tools/workspace:junit5.bzl", "java_junit5_test")
 
 project()
 
@@ -14,5 +16,18 @@ java_binary(
         "//jvm-toxcore-c",
         "@log4j_log4j//jar",
         "@org_slf4j_slf4j_log4j12//jar",
+    ],
+)
+
+java_junit5_test(
+    name = "echobot-jvm-test",
+    size = "small",
+    srcs = glob(["src/test/java/**/*.java"]),
+    jvm_flags = ["-Djava.library.path=jvm-toxcore-c"],
+    test_package = "im.tox.echobot",
+    deps = [
+        ":echobot-jvm",
+        "//jvm-toxcore-api",
+        "//jvm-toxcore-c",
     ],
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: '{build}'
 
 install:
   - choco install maven
-  - set JAVA_HOME=C:\Program Files\Java\jdk1.8.0_181
+  - set JAVA_HOME=C:\Program Files\Java\jdk11
 
 build_script:
   - mvn clean package --batch-mode -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
     <artifactId>echobot</artifactId>
     <version>0.1.0</version>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -53,7 +59,7 @@
         <dependency>
             <groupId>org.toktok</groupId>
             <artifactId>tox4j-c_2.11</artifactId>
-            <version>0.1.3</version>
+            <version>0.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.toktok</groupId>


### PR DESCRIPTION
It's not a simple `java_test`, because in Java world, everything has to
be complicated and fancy. JUnit5 requires special test runner plugins in
Maven, so now we have our own special test runner plugin in bazel, taken
from [junit5-jupiter-starter-bazel](https://github.com/junit-team/junit5-samples/blob/master/junit5-jupiter-starter-bazel/junit5.bzl).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/echobot-jvm/11)
<!-- Reviewable:end -->
